### PR TITLE
Bugfix for selecting a role when multiple roles have the same prefix

### DIFF
--- a/lib/dsl/ansible
+++ b/lib/dsl/ansible
@@ -58,14 +58,14 @@ assert_ansible_syntax() {
 assert_ansible_run() {
   if [[ -z "${ROLESPEC_TURBO_MODE}" || -n "${ROLESPEC_PLAYBOOK_MODE}" ]]; then
     ansible_run "Run playbook"
-    ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local ${ROLESPEC_ANSIBLE_OPTS}
+    ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local
   fi
 }
 
 assert_playbook_idempotent() {
   if [[ -z "${ROLESPEC_TURBO_MODE}" ]]; then
     ansible_run "Re-run playbook"
-    assert_in "$(ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local ${ROLESPEC_ANSIBLE_OPTS})" \
+    assert_in "$(ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local)" \
                "changed=0.*failed=0"
   fi
 }


### PR DESCRIPTION
Instruct grep to only return matches that have no trailing characters so that we only get back the match we want when multiple roles have the same prefix, e.g:
-    nginx
-    nginx-php
-    nginx-ssl
