### PR TITLE
Avoid often `apt-get update` 

### DIFF
--- a/lib/setup-env
+++ b/lib/setup-env
@@ -81,7 +81,13 @@ run_common_tasks() {
       local last_update_epoch="$(date "+%s" -d "$(stat -c %y /var/lib/apt/periodic/update-stamp)")"
       local time_difference=$((now_epoch - last_update_epoch))
     else
-      local time_difference=999999
+      local now_epoch="$(date "+%s")"
+      local last_update_epoch=$(stat -c %Y /var/lib/apt/lists/* | sort -nr | head -1)
+      if [ -n "$last_update_epoch" ] ; then
+	  local time_difference=$((now_epoch - last_update_epoch))
+      else
+	  local time_difference=999999
+      fi
     fi
 
     if [[ ${time_difference} -gt 86400 ]]; then

--- a/lib/setup-env
+++ b/lib/setup-env
@@ -76,18 +76,17 @@ run_common_tasks() {
     local update_file="/var/lib/apt/periodic/update-stamp"
 
     # Only run apt-get update when it is stale
+    local now_epoch="$(date "+%s")"
+    local last_update_epoch time_difference
     if [[ -f "${update_file}" ]]; then
-      local now_epoch="$(date "+%s")"
-      local last_update_epoch="$(date "+%s" -d "$(stat -c %y /var/lib/apt/periodic/update-stamp)")"
-      local time_difference=$((now_epoch - last_update_epoch))
+	last_update_epoch=$(stat -c %Y /var/lib/apt/periodic/update-stamp)
     else
-      local now_epoch="$(date "+%s")"
-      local last_update_epoch=$(stat -c %Y /var/lib/apt/lists/* | sort -nr | head -1)
-      if [ -n "$last_update_epoch" ] ; then
-	  local time_difference=$((now_epoch - last_update_epoch))
-      else
-	  local time_difference=999999
-      fi
+	last_update_epoch=$(stat -c %Y /var/lib/apt/lists/* | sort -nr | head -1)
+    fi
+    if [ -n "$last_update_epoch" ] ; then
+	time_difference=$((now_epoch - last_update_epoch))
+    else
+	time_difference=999999
     fi
 
     if [[ ${time_difference} -gt 86400 ]]; then


### PR DESCRIPTION
To determine if the apt package list is stale, not only look at the time-stamp of /var/lib/apt/periodic/update-stamp, but also check the time-stamps of the downloaded package lists.