### PR TITLE
Fixes assert_in_file and adds iptable rules

### DIFF
--- a/lib/dsl/base
+++ b/lib/dsl/base
@@ -59,9 +59,11 @@ assert_in_file() {
   fi
 
   if [[ "${3}" == "!" ]]; then
-    sudo grep -E -q "${2}" "${1}" \
-    && (fail "Not in file '${filename}'" "${2}" "${1}") \
-    || (pass "Not in file '${filename}'" "${2}" "${line_match}")
+    if sudo grep -E -q "${2}" "${1}"; then
+      fail "Not in file '${filename}'" "${2}" "${1}"
+    else
+      pass "Not in file '${filename}'" "${2}" "${line_match}"
+    fi
   else
     sudo grep -E -q "${2}" "${1}" \
     && (pass "In file '${filename}'" "${2}" "${line_match}") \

--- a/tests/test-cli
+++ b/tests/test-cli
@@ -14,6 +14,10 @@ setup_test() {
     rm -rf "${ROLESPEC_TEST_SELF_RUNTIME}"
   fi
 
+  # Add a rule so the assert_iptables_allow has a chance to succeed
+  # whatever the current iptable rules are
+  sudo /sbin/iptables -I OUTPUT -m tcp -p tcp -m comment --comment "ROLESPEC TEMP RULE" -j ACCEPT
+
   mkdir -p "${ROLESPEC_TEST_SELF_RUNTIME}/roles"
   mkdir -p "${ROLESPEC_TEST_SELF_RUNTIME}/tests"
 
@@ -111,6 +115,8 @@ teardown_test() {
   if [[ "${ROLESPEC_TEST_SELF_MONIT}" -eq 1 ]]; then
     sudo apt-get -yq --purge remove monit 2> /dev/null
   fi
+
+  sudo /sbin/iptables -D OUTPUT -m tcp -p tcp -m comment --comment "ROLESPEC TEMP RULE" -j ACCEPT
 
   kill -9 "${ROLESPEC_TEST_SELF_SERVER}"
 }


### PR DESCRIPTION
* Added iptables rules

Some systems come with empty iptables rules. In this context, the
`assert_iptables_allow "tcp"` test would fail.
This patch adds a rule during test setup, and removes it at test
teardown so the aformentionned test can match something.

* Fixed assert_in_file

In the 'negate' part of the function, `assert_in_file` was previously
written as bash `&& fail || pass` chain.
However, since fail() exits with 1, the 'or' (`||`) part was always
executed too.
So when `assert_in_file` was called with a string that WAS in the file
(and thus, was supposed to returl FAIL), il always returns two tests
results (FAIL, then PASS).
The logic has been changed so only fail xor pass is now called.

However, since rolespec own test suite rely on displaying 'FAIL' or
'PASS' in the console, there is currently no way to write a regression
test for rolespec own test suite, since it would mean writing, on
purpose, a test that fails and check that the test indeed FAILs (and
doesn't FAIL and then PASS), which is not possible.