### PR TITLE
Adds support for library path setting from env

### DIFF
--- a/bin/rolespec
+++ b/bin/rolespec
@@ -3,8 +3,17 @@
 # rolespec: A shell based test library for Ansible
 # Copyright (C) 2014 Nick Janetakis <nick.janetakis@gmail.com>
 
-
 set -e
+
+detect_library_path() {
+  echo "############################"
+  # Set the lib path based on how RoleSpec is being ran
+  if [[ -n "${ROLESPEC_TRAVIS}" || "${ROLESPEC_TEST_SELF}" ]]; then
+    ROLESPEC_LIB="lib"
+  else
+    ROLESPEC_LIB="/usr/local/lib/rolespec"
+  fi
+}
 
 # Travis detection
 if [[ -n "${TRAVIS_REPO_SLUG}" ]]; then
@@ -13,11 +22,9 @@ if [[ -n "${TRAVIS_REPO_SLUG}" ]]; then
   ROLESPEC_TRAVIS_ROLES_PATH=":$(dirname "${TRAVIS_BUILD_DIR}")"
 fi
 
-# Set the lib path based on how RoleSpec is being ran
-if [[ -n "${ROLESPEC_TRAVIS}" || "${ROLESPEC_TEST_SELF}" ]]; then
-  ROLESPEC_LIB="lib"
-else
-  ROLESPEC_LIB="/usr/local/lib/rolespec"
+echo "################# ${ROLESPEC_LIB}"
+if [[ -z "${ROLESPEC_LIB}" ]]; then
+  detect_library_path
 fi
 
 . "${ROLESPEC_LIB}/ui"


### PR DESCRIPTION
Actually, rolespec is set depending whether you're running under travis
or not. Under travis, it uses libs in ./libs, otherwise, it assumes to
be installed via `make install` and uses `/usr/local/lib/rolespec`

However, this behavior prevents installation under travis, which can be
useful in some circumstances.

This patch add the possibility to set lib path before calling the
script. 
  - if `ROLESPEC_LIB` environment variable is set, rolespec will use
this path to load it's bash libraries.
  - if `ROLESPEC_LIB` is not set, the previous behavior is maintained (i.e.
use `./lib` under Travis, and `/usr/local/lib/rolespec` otherwise.

So, in order to use a rolespec installed with `make install` under
Travis, you can issue:

    ROLESPEC_LIB=/usr/local/lib/rolespec rolespec ...