### PR TITLE
Fixes ~vagrant/.ssh/known_hosts being clobbered

### DIFF
--- a/lib/setup-env
+++ b/lib/setup-env
@@ -98,7 +98,7 @@ run_common_tasks() {
     if [ ! -f  ~/.ssh/id_rsa ] ; then
 	echo -e "y\n" | ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa
     fi
-    ssh-keyscan "${ROLESPEC_FQDN}" > ~/.ssh/known_hosts
+    ssh-keyscan "${ROLESPEC_FQDN}" >> ~/.ssh/known_hosts
 
     rolespec_run "Create global git user"
     git config --global user.email "test@user.com" && git config --global user.name "Hi"


### PR DESCRIPTION
Appending ROLESPEC_FQDN instead of overwriting ~vagrant/.ssh/known_hosts
since some setups requires host keys to be added too.
Use case: internal Entreprise Github server with roles being ssh-pulled