### PR TITLE
Add long version of idempotent playbook check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ The same test case using RoleSpec
 
   assert_playbook_runs
   assert_playbook_idempotent
+  assert_playbook_idempotent_long
 
   assert_permission "/srv/users/testapp" "751"
   assert_user_in_group "testuser" "audio"
@@ -378,6 +379,8 @@ below.
     - Performs a syntax check **and** runs ansible in check mode **and** runs the playbook once
 - ``assert_playbook_idempotent``
     - Re-runs the playbook checking for 0 changes
+- ``assert_playbook_idempotent_long``
+    - Re-runs the playbook checking for 0 changes with periodic output
 
 Basic assertions
 ````````````````

--- a/lib/dsl/ansible
+++ b/lib/dsl/ansible
@@ -92,6 +92,15 @@ assert_playbook_idempotent() {
   fi
 }
 
+assert_playbook_idempotent_long() {
+  if [[ -z "${ROLESPEC_TURBO_MODE}" ]]; then
+    ansible_run "Re-run playbook"
+    tempfile="$(mktemp)"
+    ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local | tee --append ${tempfile}
+    assert_in_file "${tempfile}" "changed=0.*unreachable=0.*failed=0"
+  fi
+}
+
 assert_playbook_check_runs() {
   assert_ansible_syntax "${@}"
   assert_ansible_check_diff "${@}"


### PR DESCRIPTION
Some playbooks might take very long to be processed, sometimes even more
than 10 minutes. Because Travis-CI has a timeout of 10 minutes without
any output, it might leave tests errored out.

'assert_playbook_idempotent_long' function is the same as
'assert_playbook_idempotent', but it will send the output periodically
to STDOUT to satisfy Travis.