### PR TITLE
Fixed problem in assert_in_file when pattern looks like grep parm.

### DIFF
--- a/lib/dsl/base
+++ b/lib/dsl/base
@@ -59,13 +59,13 @@ assert_in_file() {
   fi
 
   if [[ "${3}" == "!" ]]; then
-    if sudo grep -E -q "${2}" "${1}"; then
+    if sudo grep -E -q -e "${2}" "${1}"; then
       fail "Not in file '${filename}'" "${2}" "${1}"
     else
       pass "Not in file '${filename}'" "${2}" "${line_match}"
     fi
   else
-    sudo grep -E -q "${2}" "${1}" \
+    sudo grep -E -q -e "${2}" "${1}" \
     && (pass "In file '${filename}'" "${2}" "${line_match}") \
     || (fail "In file '${filename}'" "${2}" "${1}")
   fi


### PR DESCRIPTION
https://travis-ci.org/debops/ansible-grub/builds/98327978#L1039

`-e` was already used in the first `grep`, but forgotten in the later once …