### PR TITLE
Allow to launch rolespec with a role inside a tree

### DIFF
--- a/bin/rolespec
+++ b/bin/rolespec
@@ -46,7 +46,8 @@ set_role_name() {
     ROLESPEC_ROLE="$(basename "${TRAVIS_REPO_SLUG}")"
   else
     ROLESPEC_ROLE_NAME="${ROLESPEC_ROLE_SOURCE}"
-    ROLESPEC_ROLE="$(ls "${ROLESPEC_ROLES}" | grep "${ROLESPEC_ROLE_NAME}$")"
+    ROLESPEC_ROLE="$(find "${ROLESPEC_ROLES}" -type d -printf '%P\n' | \
+                   grep "^${ROLESPEC_ROLE_NAME}$")"
   fi
 }
 
@@ -55,8 +56,9 @@ set_dynamic_paths() {
     ROLESPEC_TEST="${ROLESPEC_TRAVIS_TESTS}/${ROLESPEC_ROLE}"
     ROLESPEC_META="${TRAVIS_BUILD_DIR}/${ROLESPEC_META}"
   else
-    ROLESPEC_TEST="${ROLESPEC_TESTS}/$(ls "${ROLESPEC_TESTS}" | \
-                   grep "${ROLESPEC_ROLE_NAME}$")"
+    ROLESPEC_TEST="${ROLESPEC_TESTS}/$(\
+                   find "${ROLESPEC_TESTS}" -type d -printf '%P\n' | \
+                   grep "^${ROLESPEC_ROLE_NAME}$")"
     ROLESPEC_META="${ROLESPEC_TEST}/${ROLESPEC_META}"
   fi
 


### PR DESCRIPTION
Example:

```bash
$ tree roles
roles
`- my
   `- deep
      |- role1
      |  `- tasks
      |     `- main.yml
      |- role2
      |  `- tasks
      |     `- main.yml
      `- role3
         `- tasks
            `- main.yml

$ rolespec -r my/deep/role1
```