### PR TITLE
Re-enable unit test

### DIFF
--- a/bin/rolespec
+++ b/bin/rolespec
@@ -47,7 +47,7 @@ set_role_name() {
   else
     ROLESPEC_ROLE_NAME="${ROLESPEC_ROLE_SOURCE}"
     ROLESPEC_ROLE="$(find -L "${ROLESPEC_ROLES}" -type d -printf '%P\n' | \
-                   grep "^${ROLESPEC_ROLE_NAME}$")"
+                   grep "${ROLESPEC_ROLE_NAME}$")"
   fi
 }
 
@@ -58,7 +58,7 @@ set_dynamic_paths() {
   else
     ROLESPEC_TEST="${ROLESPEC_TESTS}/$(\
                    find -L "${ROLESPEC_TESTS}" -type d -printf '%P\n' | \
-                   grep "^${ROLESPEC_ROLE_NAME}$")"
+                   grep "${ROLESPEC_ROLE_NAME}$")"
     ROLESPEC_META="${ROLESPEC_TEST}/${ROLESPEC_META}"
   fi
 

--- a/tests/test-cli
+++ b/tests/test-cli
@@ -25,6 +25,7 @@ fi
 # Execute tests
 setup_test
 
+set -e
 ROLESPEC_TEST_SELF=true TRAVIS_REPO_SLUG="" TRAVIS_BUILD_DIR="" bash bin/rolespec -r "${ROLESPEC_TEST_SELF_ROLE}"
 
 teardown_test


### PR DESCRIPTION
On grep with ^ rolespec is not runing ansible playbook, because role name not match. 
testuser.testrole not match testrole 