### PR TITLE
Improve output

### DIFF
--- a/bin/rolespec
+++ b/bin/rolespec
@@ -15,23 +15,6 @@ detect_library_path() {
   fi
 }
 
-# Travis detection
-if [[ -n "${TRAVIS_REPO_SLUG}" ]]; then
-  ROLESPEC_ROLE="${TRAVIS_REPO_SLUG}"
-  ROLESPEC_TRAVIS=true
-  ROLESPEC_TRAVIS_ROLES_PATH=":$(dirname "${TRAVIS_BUILD_DIR}")"
-fi
-
-echo "################# ${ROLESPEC_LIB}"
-if [[ -z "${ROLESPEC_LIB}" ]]; then
-  detect_library_path
-fi
-
-. "${ROLESPEC_LIB}/ui"
-. "${ROLESPEC_LIB}/config"
-. "${ROLESPEC_LIB}/cli"
-. "${ROLESPEC_LIB}/setup-env"
-
 enforce_working_directories() {
   if [[ -n "${ROLESPEC_TRAVIS}" ]]; then
     # Ensure the roles paths exist when running on Travis
@@ -67,6 +50,23 @@ set_dynamic_paths() {
   ROLESPEC_PLAYBOOK="${ROLESPEC_TEST}/${ROLESPEC_PLAYBOOK}"
   ROLESPEC_SCRIPT="${ROLESPEC_TEST}/test"
 }
+
+# Travis detection
+if [[ -n "${TRAVIS_REPO_SLUG}" ]]; then
+  ROLESPEC_ROLE="${TRAVIS_REPO_SLUG}"
+  ROLESPEC_TRAVIS=true
+  ROLESPEC_TRAVIS_ROLES_PATH=":$(dirname "${TRAVIS_BUILD_DIR}")"
+fi
+
+echo "################# ${ROLESPEC_LIB}"
+if [[ -z "${ROLESPEC_LIB}" ]]; then
+  detect_library_path
+fi
+
+. "${ROLESPEC_LIB}/ui"
+. "${ROLESPEC_LIB}/config"
+. "${ROLESPEC_LIB}/cli"
+. "${ROLESPEC_LIB}/setup-env"
 
 # Perform pre-setup tasks to set variables
 enforce_working_directories

--- a/bin/rolespec
+++ b/bin/rolespec
@@ -32,7 +32,7 @@ set_role_name() {
   else
     ROLESPEC_ROLE_NAME="${ROLESPEC_ROLE_SOURCE}"
     ROLESPEC_ROLE="$(find -L "${ROLESPEC_ROLES}" -type d -printf '%P\n' | \
-                   grep "${ROLESPEC_ROLE_NAME}$")"
+                   grep "${ROLESPEC_ROLE_NAME}$" || true)"
   fi
 }
 
@@ -43,7 +43,7 @@ set_dynamic_paths() {
   else
     ROLESPEC_TEST="${ROLESPEC_TESTS}/$(\
                    find -L "${ROLESPEC_TESTS}" -type d -printf '%P\n' | \
-                   grep "${ROLESPEC_ROLE_NAME}$")"
+                   grep "${ROLESPEC_ROLE_NAME}$" || true)"
     ROLESPEC_META="${ROLESPEC_TEST}/${ROLESPEC_META}"
   fi
 

--- a/bin/rolespec
+++ b/bin/rolespec
@@ -6,13 +6,15 @@
 set -e
 
 detect_library_path() {
-  echo "############################"
-  # Set the lib path based on how RoleSpec is being ran
-  if [[ -n "${ROLESPEC_TRAVIS}" || "${ROLESPEC_TEST_SELF}" ]]; then
-    ROLESPEC_LIB="lib"
-  else
-    ROLESPEC_LIB="/usr/local/lib/rolespec"
+  if [[ -z "${ROLESPEC_LIB}" ]]; then
+    # Set the lib path based on how RoleSpec is being ran
+    if [[ -n "${ROLESPEC_TRAVIS}" || "${ROLESPEC_TEST_SELF}" ]]; then
+      ROLESPEC_LIB="lib"
+    else
+      ROLESPEC_LIB="/usr/local/lib/rolespec"
+    fi
   fi
+  echo "################# ROLESPEC_LIB=${ROLESPEC_LIB}"
 }
 
 enforce_working_directories() {
@@ -58,10 +60,7 @@ if [[ -n "${TRAVIS_REPO_SLUG}" ]]; then
   ROLESPEC_TRAVIS_ROLES_PATH=":$(dirname "${TRAVIS_BUILD_DIR}")"
 fi
 
-echo "################# ${ROLESPEC_LIB}"
-if [[ -z "${ROLESPEC_LIB}" ]]; then
-  detect_library_path
-fi
+detect_library_path
 
 . "${ROLESPEC_LIB}/ui"
 . "${ROLESPEC_LIB}/config"

--- a/lib/config
+++ b/lib/config
@@ -56,6 +56,7 @@ elif [[ -n "${ROLESPEC_TRAVIS}" ]]; then
 else
   ROLESPEC_RUNTIME="$(find_up)"
 fi
+echo "################# ROLESPEC_RUNTIME=${ROLESPEC_RUNTIME}"
 
 # Working paths
 ROLESPEC_ROLES="${ROLESPEC_RUNTIME}/roles"

--- a/lib/setup-env
+++ b/lib/setup-env
@@ -17,6 +17,12 @@ enforce_rolespec_directory() {
   fi
 }
 
+enforce_role_exists() {
+  if [[ -z "${ROLESPEC_ROLE}" ]]; then
+    error "Role not found:\n${ROLESPEC_ROLE_SOURCE} in ${ROLESPEC_ROLES}\n"
+  fi
+}
+
 enforce_test_exists() {
   if [ ! -f "${ROLESPEC_SCRIPT}" ]; then
     error "Test script not found:\n${ROLESPEC_SCRIPT}\n"
@@ -120,6 +126,7 @@ run_common_tasks() {
 presetup() {
   enforce_arguments
   enforce_rolespec_directory
+  enforce_role_exists
 
   if [[ -n "$ROLESPEC_TRAVIS" ]]; then
     clone_url


### PR DESCRIPTION
Add some output for some variable + errors so you are able to understand why it's not working.
When launching `rolespec` with a wrong rolename or missing test now fails with a helpful error message.
When launching `rolespec` in wrong folder, outputting that `ROLESPEC_RUNTIME` is empty is a good help.
`ROLESPEC_LIB` was only displayed with global value, so there was only `#################` displayed when using the detection.
