### PR TITLE
Use `become` instead of the deprecated `sudo` keyword

### DIFF
--- a/lib/setup-env
+++ b/lib/setup-env
@@ -52,7 +52,7 @@ inject_placeholders() {
 ---
 
 - hosts: '${ROLESPEC_FQDN}'
-  sudo: true
+  become: True
 
   roles:
     - role: '${ROLESPEC_ROLE}'


### PR DESCRIPTION
I am tired of seeing "[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and" :wink: