### PR TITLE
Run Ansible with `--diff`` in assert_playbook_idempotent

### DIFF
--- a/lib/dsl/ansible
+++ b/lib/dsl/ansible
@@ -87,7 +87,7 @@ assert_ansible_run() {
 assert_playbook_idempotent() {
   if [[ -z "${ROLESPEC_TURBO_MODE}" ]]; then
     ansible_run "Re-run playbook"
-    assert_in "$(ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local)" \
+    assert_in "$(ansible-playbook "${ROLESPEC_PLAYBOOK}" "${@}" --connection=local --diff)" \
                "changed=0.*unreachable=0.*failed=0"
   fi
 }


### PR DESCRIPTION
This should help with debugging when the assertion fails.

Example usage: https://travis-ci.org/debops/ansible-apt/builds/216344730#L824-L826
Example usage: https://github.com/debops/ansible-apt/pull/88