### PR TITLE
Extend MySQL package list with packages from Ubuntu Trusty

### DIFF
--- a/lib/config-debian
+++ b/lib/config-debian
@@ -1,4 +1,4 @@
 ROLESPEC_POSTGRESQL_LIBS="postgresql libpq-dev libpq5 postgresql-client-common postgresql-common"
-ROLESPEC_MYSQL_LIBS="mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5"
+ROLESPEC_MYSQL_LIBS="mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5 mysql-server-5.6 mysql-server-core-5.6 mysql-client-5.6 mysql-client-core-5.6"
 
 ROLESPEC_INSTALLER_COMMAND='apt-get -yq install '


### PR DESCRIPTION
Because Ubuntu Precise is EoL Travis-CI now offers build images based on Ubuntu Trusty. Those contain a new MySQL version installed by default. Make sure they will be properly removed when depending on `$ROLESPEC_MYSQL_LIBS`